### PR TITLE
Removed redundant mailer in messages_controller

### DIFF
--- a/app/controllers/guest/messages_controller.rb
+++ b/app/controllers/guest/messages_controller.rb
@@ -34,7 +34,7 @@ class Guest::MessagesController < Guest::GuestController
     end
     if @message.save
       # TODO: Transform email notification into a SuckerPunch job
-      UserMailer.receive_message(@conversation.messages.last).deliver
+      # UserMailer.receive_message(@conversation.messages.last).deliver
       render json: nil # Returning nothing will result in jQuery ajax error
     else
       head :internal_server_error


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1108894/stories/100479518

Because we recently switched to Mandrill for most PHS mailers, code that uses Maligun has become redundant and for the most part had been commented out. This one section of code with the messages_controller was still calling a redundant mailer. However, given recent discussions, I'm not sure whether we should keep old code related to Mailgun commented out, or whether we should remove it completely.

That said, it should fix the Raygun error we've been having for some time. Thats when this code section gets called, because the UserMailer.receive_message method has been commented out, it throws an error.
# Fixes bug <100479518>
