### PR TITLE
Used the rails jquery_ujs library to add a submitting/disable state t…

### DIFF
--- a/app/views/devise/registrations/create.js.haml
+++ b/app/views/devise/registrations/create.js.haml
@@ -1,9 +1,6 @@
 - if user_signed_in?
   $(location).attr('href', "#{@rpath}");
-  console.log("im here");
-  console.log("im here");
   location.reload();
-  console.log("im here");
 - else
   $('#flash_error_sign_up').html("#{resource.errors.full_messages.join("<br>").html_safe}")
   $('#flash_error_sign_up').addClass('text-danger')

--- a/app/views/homestays/_modal_add_pet.html.slim
+++ b/app/views/homestays/_modal_add_pet.html.slim
@@ -91,7 +91,7 @@
             = f.input :energy_level, label: false , input_html: { class: 'slider hidden', data: { 'slider-id' => 'energy_level', 'slider-min' => 1, 'slider-max' => 5, 'slider-step' => 1, 'slider-value' => f.object.energy_level.present? ? f.object.energy_level : 3 } } 
     .row.text-box-centered
       #flash_error_with_pet role='alert'
-      = f.submit 'Add Your Pet', class: 'btn btn-mint btn-block submitEnquiry'
+      = f.submit 'Add Your Pet', class: 'btn btn-mint btn-block submitEnquiry', disable_with: "Adding Pet to Enquiry..."
   button.pull-left.hidden-xs style="margin-top: -15px; margin-left: -7px"type='button' class='close' data-dismiss='modal'
     .sr-only Close
     i.fa.fa-reply.text-xs 

--- a/app/views/homestays/_modal_enquiry.html.slim
+++ b/app/views/homestays/_modal_enquiry.html.slim
@@ -29,7 +29,7 @@
         = f.input :reuse_message, as: :hidden, input_html: { value: 1 }
     .text-box-centered.text-center#flash_error role='alert' style="margin-bottom: 10px; min-height:40px"
     .text-box-centered
-      = f.submit 'SUBMIT ENQUIRY', class: 'btn btn-mint btn-block' 
+      = f.submit 'SUBMIT ENQUIRY', class: 'btn btn-mint btn-block' , disable_with: "Submitting..." 
     button.pull-left.hidden-xs style='margin-top: -15px; margin-left: -7px' type='button' class='close' data-dismiss='modal'
       .sr-only Close
       i.fa.fa-reply.text-xs   

--- a/app/views/homestays/_modal_sign_in.html.slim
+++ b/app/views/homestays/_modal_sign_in.html.slim
@@ -23,7 +23,7 @@
         = password_field_tag 'user[password]', nil, class: 'form-control', placeholder: 'Password'
       .text-box-centered#flash_error_sign_in
     .form-group.text-box-centered
-      = submit_tag 'LOG IN', class: 'btn btn-mint form-control submit'
+      = submit_tag 'LOG IN', class: 'btn btn-mint form-control submit', disable_with: "Logging in..." 
       label.checkbox-inline
         = check_box_tag 'user[remember_me]', 1, true
         span.text-muted.text-sm Remember Me

--- a/app/views/homestays/_modal_sign_up.html.slim
+++ b/app/views/homestays/_modal_sign_up.html.slim
@@ -67,7 +67,7 @@
       .form-group
         = f.hidden_field :accept_terms, value: 1
       .form-group.text-box-centered
-        = f.submit "JOIN US. IT'S FREE", class: 'btn btn-mint form-control submit' 
+        = f.submit "JOIN US. IT'S FREE", class: 'btn btn-mint form-control submit', disable_with: "Creating User..." 
     p.help-block.text-center.text-sm
       small
         | By joining PetHomeStay, you agree to our 


### PR DESCRIPTION
…o all form buttons within the enquiry modal flow.

https://www.pivotaltracker.com/n/projects/1108894/stories/99874888

The problem occurred when users filled out any of the modal forms and hit submit. Delays in form submission due to network conditions would keep the form unresponsive - not giving the user any feedback as to whats happening. Eventually the next form would render, but impatient users were found to resubmit the form multiple times causing both errors or multiple creations of the same pet/enquiry.

This fix uses the Jquery_ujs helper library. Used it to disable the submission button of each modal form to prevent extra/miss clicks and repeated submissions. The button also shows custom text when in the submitted state showing what's happening to the user before the next form renders.

Also removed some console log code (used for debugging form renders) within a create.js file.
# Fixes feature <99874888>
