### PR TITLE
WireFrames for supporters

### DIFF
--- a/app/assets/javascripts/host/supporters/supporters.js
+++ b/app/assets/javascripts/host/supporters/supporters.js
@@ -1,0 +1,47 @@
+$(document).ready( function() {
+
+    window.fbAsyncInit = function() {
+        FB.init({
+            appId: "#{ENV['APP_ID'] || '382802968555135' }",
+            cookie: true,
+            status: true,
+            xfbml: true,
+            version: 'v2.1'
+        });
+
+        $('.fb-share-btn.fb-host-to-guest-review').on('click', function() {
+            var data = $(this).data();
+            var fb_description = "Review: " + data.review
+            FB.ui({
+                method: 'feed',
+                link: "https://www.pethomestay.com.au",
+                name: data.title,
+                caption: "Australia's no. 1 pet sitting community",
+                description: fb_description
+            }, function(response) {});
+        });
+
+        $('.fb-share-btn.fb-user-support').on('click', function() {
+            var data = $(this).data();
+            FB.ui({
+                method: 'feed',
+                link: data.url,
+                name: "Please give me your support",
+                caption: "Australia's no. 1 pet sitting community",
+                description: "I could use a helping hand from friends. Please give me your support by clicking on this post and telling the community that I love pets!"
+            }, function(response) {});
+        });
+    };
+
+    (function(d, s, id) {
+        var js, fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) {
+            return;
+        }
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "//connect.facebook.net/en_US/sdk.js";
+        fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
+
+});

--- a/app/controllers/host/supporters_controller.rb
+++ b/app/controllers/host/supporters_controller.rb
@@ -1,26 +1,26 @@
 class Host::SupportersController < Host::HostController
-respond_to :html
+respond_to :html 
 
+  # Lists out the number of recommendations/support that a user has gotten on the same page
   def index
+
     @recommendations = current_user.recommendations.order('created_at DESC').paginate(page: params[:page], per_page: 10)
-    puts "Im being called again and again"
-    @emails = Rails.cache.fetch("emails") 
+    
+    # Check Cache for user emails
+    @emails = Rails.cache.fetch(current_user.hex) 
   end
 
+  # Catch the gmail contacts data here, filter out the email addresses,
+  # and add them to the cache. 
   def invite_emails
+   
     @contacts ||= request.env['omnicontacts.contacts']
     @emails = @contacts.map { |contact| contact[:emails] [0][:email] if contact[:emails] } 
-    puts @emails
-    # listbox sect2
-
-    Rails.cache.write("emails", @emails) 
-    # @contacts.each do |contact|
-      # UserMailer.invite_email(contact[:email], current_user).deliver
-    # end
+    
+    Rails.cache.write(current_user.hex, @emails) 
+   
     redirect_to host_supporters_path, :notice => "Invitaion mail sent successfully"  
-  end  
-
-
+  end 
 
   # Route for sending supporter invite emails after users have filtered through them.
   # This is an Ajax call that should return a 200 response if successful
@@ -28,10 +28,16 @@ respond_to :html
   # The view is to add the logic of what to show the host and when.
   def send_invite_emails
 
-
-
-
+    # get the information from JSON
+    @emails = params[:emails]
+    @emails.each do |address|
+      UserMailer.invite_email(address, current_user).deliver
+    end
+    # respond to the client via json response
+    msg = { :status => "ok", :message => "Success!", :html => "<b>...</b>" }
+    render :json => msg.to_json
+    
+    # Remove from cache
+    Rails.cache.delete(current_user.hex)
   end  
-
-
 end

--- a/app/controllers/host/supporters_controller.rb
+++ b/app/controllers/host/supporters_controller.rb
@@ -3,14 +3,35 @@ respond_to :html
 
   def index
     @recommendations = current_user.recommendations.order('created_at DESC').paginate(page: params[:page], per_page: 10)
+    puts "Im being called again and again"
+    @emails = Rails.cache.fetch("emails") 
   end
 
-
   def invite_emails
-    @contacts = request.env['omnicontacts.contacts']
-    @contacts.each do |contact|
-      UserMailer.invite_email(contact[:email], current_user).deliver
-    end
+    @contacts ||= request.env['omnicontacts.contacts']
+    @emails = @contacts.map { |contact| contact[:emails] [0][:email] if contact[:emails] } 
+    puts @emails
+    # listbox sect2
+
+    Rails.cache.write("emails", @emails) 
+    # @contacts.each do |contact|
+      # UserMailer.invite_email(contact[:email], current_user).deliver
+    # end
     redirect_to host_supporters_path, :notice => "Invitaion mail sent successfully"  
   end  
+
+
+
+  # Route for sending supporter invite emails after users have filtered through them.
+  # This is an Ajax call that should return a 200 response if successful
+  # or some 503 response if not successful.
+  # The view is to add the logic of what to show the host and when.
+  def send_invite_emails
+
+
+
+
+  end  
+
+
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -60,8 +60,6 @@ class UserMailer < ActionMailer::Base
     mandrill_client.messages.send_template template_name,template_content, message
   end
 
-
-
   def leave_feedback(to, subject, enquiry)
     @user = to
     @subject = subject

--- a/app/views/host/supporters/index.html.slim
+++ b/app/views/host/supporters/index.html.slim
@@ -7,142 +7,128 @@
 
 = stylesheet_link_tag 'bootstrap-multiselect'
 = javascript_include_tag 'bootstrap-multiselect'
+= javascript_include_tag 'host/supporters/supporters.js'
 
-javascript:
-  window.fbAsyncInit = function() {
-    FB.init({
-      appId      : "#{ENV['APP_ID'] || '382802968555135' }",
-      cookie     : true,
-      status     : true,
-      xfbml      : true,
-      version    : 'v2.1'
-    });
-
-    $('.fb-share-btn.fb-host-to-guest-review').on('click', function() {
-      var data = $(this).data();
-      var fb_description = "Review: " + data.review
-      FB.ui(
-      {
-        method: 'feed',
-        link: "https://www.pethomestay.com.au",
-        name: data.title,
-        caption: "Australia's no. 1 pet sitting community",
-        description: fb_description
-      }, function(response){});
-    });
-
-    $('.fb-share-btn.fb-user-support').on('click', function() {
-      var data = $(this).data();
-      FB.ui(
-      {
-        method: 'feed',
-        link: data.url,
-        name: "Please give me your support",
-        caption: "Australia's no. 1 pet sitting community",
-        description: "I could use a helping hand from friends. Please give me your support by clicking on this post and telling the community that I love pets!"
-      }, function(response){});
-    });
-  };
-
-  (function(d, s, id){
-     var js, fjs = d.getElementsByTagName(s)[0];
-     if (d.getElementById(id)) {return;}
-     js = d.createElement(s); js.id = id;
-     js.src = "//connect.facebook.net/en_US/sdk.js";
-     fjs.parentNode.insertBefore(js, fjs);
-   }(document, 'script', 'facebook-jssdk'));
 #fb-root
-
 = render layout: 'layouts/user' do
   .row
-    .panel.panel-default         
-      .panel-body
-        .pad-all.bg-gray
-          span Hosts can now invite their friends to support a specific Homestay!
-          br
-          span This means potential pet owning clients haveanother way to assess
-          span how trustworthy you are or how good a pet sitter you are. It's especially useful if you are just 
-          span starting out as a Host and don't have any reviews yet :)
-          br 
-          span It's important as it will effect how you appear in the Search Results page, when people
-          span look in their postcode area. Hosts with friends will rank higher than Hosts without
-          span Friends, but Reviews will always be the most important aspect. 
-        .col-md-12
-          .text-thin.text-center  Support that you have received from friends and family will appear here. To get more support, tell friends and family to go to the following URL 
-          .text-bold.text-danger.text-center = "www.pethomestay.com.au/support/#{current_user.hex}"
-          .text-thin.text-center Or send an invite to their emails
-        
-        .col-sm-12
-          button.btn.btn-block.fb-share-btn.fb-user-support data-url=support_url style='background: #3B5998; color: #f7f7f7;'
-            i.fa.fa-facebook 
-            span SHARE
-          button.btn.btn-block.twitter-support-btn data-href=twitter_url style='background: #55acee; color: #f7f7f7;'
-            i.fa.fa-twitter
-            span TWEET  
-
-
-
-        .col-md-12
-          - if @emails.nil?
-            a href="/contacts/gmail" Gmail
-          - else 
-            select.basic-multiple#emailsSelect multiple="true"
-              - @emails.each do |email|
-                  option value="#{email}" ="#{email}" 
-                  
-          
-      .phs-panel-body                    
-        - if @recommendations.any?
-          - @recommendations.each do |recommendation|
-            - user = User.find(recommendation.user_id)
-            .parent style="border-bottom: 1px solid #ddd;"
-              .panel-heading.feedback-head style="margin-bottom: 20px;"
-                .panel-title.phs-title
-                  .pull-left
-                    = "#{recommendation.email}"
-                    br
-                    | Reviewed:
-                    = "#{time_ago_in_words(recommendation.created_at)} ago"
-                  .pull-right
-                    .feedback-icon
-                      i.fa.fa-chevron-down   
-              .panel-body.feedback-body style="margin-top: 20px;"
-                .row
-                  .col-md-12      
-                    span "
-                    strong 
-                      = recommendation.review
-                    span "  
-
+    .pad-all.bg-gray
+      .text-md Hosts can now invite their friends to support a specific Homestay! This means potential pet owning clients have another way to assess how trustworthy you are or how good a pet sitter you are. It's especially useful if you are just starting out as a Host and don't have any reviews yet :) 
+      br
+      .text-md It's important as it will effect how you appear in the Search Results page, when people look in their postcode area. Hosts with friends will rank higher than Hosts without Friends, but Reviews will always be the most important aspect. 
+    
+    .pad-all.text-bold.text-danger.text-center = "www.pethomestay.com.au/support/#{current_user.hex}"
+    
+    a.btn.btn-block.fb-share-btn.fb-user-support data-url=support_url style='background: #3B5998; color: #f7f7f7;'
+      i.fa.fa-facebook 
+      span SHARE
+    a.btn.btn-block.twitter-support-btn data-href=twitter_url style='background: #55acee; color: #f7f7f7;'
+      i.fa.fa-twitter
+      span TWEET  
+    - if @emails.nil?
+      a.btn.btn-default.btn-block href="/contacts/gmail" Gmail
+    - else
+      .mar-top style="margin-top:5px;"
+        a.btn.btn-default.basic-multiple#emailsSelect multiple="true"
+          - @emails.each do |email|
+              option value="#{email}" ="#{email}" 
+      .mar-top style="margin-top:5px;"  
+        a.btn.btn-default#invite_users_button Invite these users.     
+      
+  - if @recommendations.any?
+    - @recommendations.each do |recommendation|
+      - user = User.find(recommendation.user_id)
+      .parent style="border-bottom: 1px solid #ddd;"
+        .panel-heading.feedback-head style="margin-bottom: 20px;"
+          .panel-title.phs-title
+            .pull-left
+              = "#{recommendation.email}"
+              br
+              | Reviewed:
+              = "#{time_ago_in_words(recommendation.created_at)} ago"
+            .pull-right
+              .feedback-icon
+                i.fa.fa-chevron-down   
+        .panel-body.feedback-body style="margin-top: 20px;"
+          .row
+            .col-md-12      
+              span "
+              strong 
+                = recommendation.review
+              span "  
 javascript:
-  
-  $('.twitter-share-btn').click( function() {
-    var height, width;
-    width = 600;
-    height = 350;
-    return window.open( $('.twitter-share-btn').data('href'), 'Tweet', 'width=' + width , 'height=' + height );
-  });
+   $(".feedback-body").hide();
+    $(".feedback-head").click(function(event) {
+        var head = $(this).children();
+        var icon = $(this).find(".feedback-icon").children();
+        var body = $(this).parent().find(".feedback-body");
+        if (body.is(":hidden")) {
+            icon.addClass("phs-rotate");
+            icon.removeClass("phs-reset");
+            head.removeClass("phs-title");
+            head.addClass("phs-title-active");
+            body.slideDown();
+        } else {
+            icon.removeClass("phs-rotate");
+            icon.addClass("phs-reset");
+            head.removeClass("phs-title-active");
+            head.addClass("phs-title");
+            body.slideUp();
+        }
+    });
 
-  $( ".feedback-body" ).hide();
-  $( ".feedback-head" ).click(function(event) {
-    var head = $(this).children();
-    var icon = $(this).find(".feedback-icon").children();
-    var body = $(this).parent().find(".feedback-body");
-    if( body.is(":hidden") ) {
-      icon.addClass("phs-rotate");
-      icon.removeClass("phs-reset");
-      head.removeClass("phs-title"); 
-      head.addClass("phs-title-active");
-      body.slideDown();
-    } else {
-      icon.removeClass("phs-rotate"); 
-      icon.addClass("phs-reset");
-      head.removeClass("phs-title-active"); 
-      head.addClass("phs-title");
-      body.slideUp();
-    }
-  });
+    $("#invite_users_button").click(function(event) {
+        if (selectedEmailArray.length > 0) {
+            $.ajax({
+                url: "#{host_send_invite_emails_path}",
+                type: 'POST',
+                data: {
+                    emails: selectedEmailArray
+                },
+                beforeSend: function(xhr) {
+                    xhr.setRequestHeader("Accept", "text/json")
+                }
+            }).done(function(response) {
+                alert("Data Saved: " + response.message);
+            });
+        } else {
+            alert('Please select contacts from list');
+        }
+    });
 
-  $('#emailsSelect').multiselect({     
-        enableCaseInsensitiveFiltering: true
-    }); 
+    $("#invite_users_button").hide();
+    var selectedEmailArray = [];
+
+    $('#emailsSelect').multiselect({
+        buttonWidth: '100%',
+        enableFiltering: true,
+        includeSelectAllOption: true,
+        enableClickableOptGroups: true,
+        maxHeight: 200,
+        onChange: function(option, checked, select) {
+
+            var found = $.inArray(option[0].value, selectedEmailArray);
+
+            // if not found inside the filtered array
+            if (found == -1 && checked) {
+
+                selectedEmailArray.push(option[0].value);
+
+            } else if (found > -1) {
+
+                selectedEmailArray.splice(found, 1);
+
+            }
+
+            if(selectedEmailArray.length > 0) {
+               
+               $("#invite_users_button").show();
+
+            } else {
+
+              $("#invite_users_button").hide();
+
+            }
+        }
+    });
+    $('#emailsSelect').multiselect('deselectAll', true);

--- a/app/views/host/supporters/index.html.slim
+++ b/app/views/host/supporters/index.html.slim
@@ -1,72 +1,13 @@
-css:
-  .feedback-head {
-    cursor : pointer;
-  }
-  .feedback-body {
-    background-color: #f7f7f7;
-    border: 1px solid #ddd;
-    border-top: none;
-  }
-  .btn-fb {
-    margin-right:5px;
-    background: #3B5998;
-    color: #f7f7f7;
-  }
-  .btn-tw {
-    background: #55acee;
-    color: #f7f7f7;
-  }
-  .phs-tab-header {
-    margin-left: -20px;
-    margin-right: -20px;
-    height: 75px;
-  }
-  .phs-title {
-    font-size: 15px;
-    line-height: 20px !important;
-    background-color: #f2f2f2;
-    color: #434343;
-    padding: 20px;
-    transition: .3s;
-  }
-  .phs-title-active {
-    font-size: 15px;
-    line-height: 20px !important;
-    background-color: #5cc1c0;
-    color: #ffffff;
-    padding: 20px;
-    transition: .3s;
-  }
-  .phs-tab-header-picture {
-    width: 40px;
-    height: 40px;
-    margin-right: 10px;
-  }
-  .phs-tab-header-picture2x {
-    width: 60px;
-    height: 60px;
-    margin-right: 10px;
-  }
-  .phs-panel-body {
-    margin-left: -20px;
-    margin-right: -20px;
-    padding: 10px 0 0 0 !important;
-  }
-  .phs-subtitle {
-    background-color: #f2f2f2;
-    color: #ababab;
-    margin: -10px 0 10px 0;
-    padding: 5px;
-    text-align: center;
-  }
-  .phs-rotate {
-    transform: rotate(-180deg);
-    transition: .3s;
-  }
-  .phs-reset {
-    transform: rotate(0deg);
-    transition: .3s;
-  }
+- support_url = "www.pethomestay.com.au/support/" + current_user.hex
+
+- twitter_url  = 'https://twitter.com/share'
+- twitter_url += "?text=I could use a helping hand from friends."
+- twitter_url += "&url=https://www.pethomestay.com.au/" + current_user.hex
+- twitter_url += '&hashtags=freecuddles'
+
+= stylesheet_link_tag 'bootstrap-multiselect'
+= javascript_include_tag 'bootstrap-multiselect'
+
 javascript:
   window.fbAsyncInit = function() {
     FB.init({
@@ -111,72 +52,77 @@ javascript:
      fjs.parentNode.insertBefore(js, fjs);
    }(document, 'script', 'facebook-jssdk'));
 #fb-root
-coffee:
-  $ ->
-    $('.twitter-share-btn').on 'click', ->
-      width  = 600
-      height = 350
-      window.open $('.twitter-share-btn').data('href'), 'Tweet', "width=#{width}, height=#{height}"
-    $('.twitter-support-btn').on 'click', ->
-      width  = 600
-      height = 350
-      window.open $('.twitter-support-btn').data('href'), 'Tweet', "width=#{width}, height=#{height}"  
 
 = render layout: 'layouts/user' do
-  .panel.panel-default style="box-shadow: none;"          
-    .panel-body.phs-panel-body
-      = image_tag 'dogs-together.jpg', class: 'img-responsive center-block', style: 'margin-bottom: 5px; padding:15px;'
-
-      .col-md-12
-        .text-thin.text-center  Support that you have received from friends and family will appear here. To get more support, tell friends and family to go to the following URL 
-        .text-bold.text-danger.text-center = "www.pethomestay.com.au/support/#{current_user.hex}"
-        .text-thin.text-center Or send an invite to their emails
-      .col-md-12
-        a href="/contacts/gmail" Gmail
-        - if @contacts.try(:any?)
-          = form_tag host_send_invite_emails_path, :method => 'post', :id => "send_invite_form" do
-            - @contacts.each do |c|
-              - unless c[:email].blank?
-                .form-group
-                  .input-group
-                    = check_box_tag 'emails[]', c[:email], false, class: 'form-control'
-                    span.input-group-addon
-                      = c[:name].blank? ? c[:email] : c[:name]
-            .form-group
-              .input-group
-                = text_area_tag 'message', nil, class: 'put_class_name'
-
-            = submit_tag 'Send Email', class: 'btn btn-primary form-control submit'
-
-      .text-thin.text-center Or use Social media and get people you know to leave you support!
-      
-      .text-center.mar-top
-        = render 'support_sharing' 
+  .row
+    .panel.panel-default         
+      .panel-body
+        .pad-all.bg-gray
+          span Hosts can now invite their friends to support a specific Homestay!
+          br
+          span This means potential pet owning clients haveanother way to assess
+          span how trustworthy you are or how good a pet sitter you are. It's especially useful if you are just 
+          span starting out as a Host and don't have any reviews yet :)
+          br 
+          span It's important as it will effect how you appear in the Search Results page, when people
+          span look in their postcode area. Hosts with friends will rank higher than Hosts without
+          span Friends, but Reviews will always be the most important aspect. 
+        .col-md-12
+          .text-thin.text-center  Support that you have received from friends and family will appear here. To get more support, tell friends and family to go to the following URL 
+          .text-bold.text-danger.text-center = "www.pethomestay.com.au/support/#{current_user.hex}"
+          .text-thin.text-center Or send an invite to their emails
         
-    .phs-panel-body                    
-      - if @recommendations.any?
-        - @recommendations.each do |recommendation|
-          - user = User.find(recommendation.user_id)
-          .parent style="border-bottom: 1px solid #ddd;"
-            .panel-heading.feedback-head style="margin-bottom: 20px;"
-              .panel-title.phs-title
-                .pull-left
-                  = "#{recommendation.email}"
-                  br
-                  | Reviewed:
-                  = "#{time_ago_in_words(recommendation.created_at)} ago"
-                .pull-right
-                  .feedback-icon
-                    i.fa.fa-chevron-down   
-            .panel-body.feedback-body style="margin-top: 20px;"
-              .row
-                .col-md-12      
-                  span "
-                  strong 
-                    = recommendation.review
-                  span "  
+        .col-sm-12
+          button.btn.btn-block.fb-share-btn.fb-user-support data-url=support_url style='background: #3B5998; color: #f7f7f7;'
+            i.fa.fa-facebook 
+            span SHARE
+          button.btn.btn-block.twitter-support-btn data-href=twitter_url style='background: #55acee; color: #f7f7f7;'
+            i.fa.fa-twitter
+            span TWEET  
+
+
+
+        .col-md-12
+          - if @emails.nil?
+            a href="/contacts/gmail" Gmail
+          - else 
+            select.basic-multiple#emailsSelect multiple="true"
+              - @emails.each do |email|
+                  option value="#{email}" ="#{email}" 
+                  
+          
+      .phs-panel-body                    
+        - if @recommendations.any?
+          - @recommendations.each do |recommendation|
+            - user = User.find(recommendation.user_id)
+            .parent style="border-bottom: 1px solid #ddd;"
+              .panel-heading.feedback-head style="margin-bottom: 20px;"
+                .panel-title.phs-title
+                  .pull-left
+                    = "#{recommendation.email}"
+                    br
+                    | Reviewed:
+                    = "#{time_ago_in_words(recommendation.created_at)} ago"
+                  .pull-right
+                    .feedback-icon
+                      i.fa.fa-chevron-down   
+              .panel-body.feedback-body style="margin-top: 20px;"
+                .row
+                  .col-md-12      
+                    span "
+                    strong 
+                      = recommendation.review
+                    span "  
 
 javascript:
+  
+  $('.twitter-share-btn').click( function() {
+    var height, width;
+    width = 600;
+    height = 350;
+    return window.open( $('.twitter-share-btn').data('href'), 'Tweet', 'width=' + width , 'height=' + height );
+  });
+
   $( ".feedback-body" ).hide();
   $( ".feedback-head" ).click(function(event) {
     var head = $(this).children();
@@ -196,3 +142,7 @@ javascript:
       body.slideUp();
     }
   });
+
+  $('#emailsSelect').multiselect({     
+        enableCaseInsensitiveFiltering: true
+    }); 

--- a/app/views/pages/dashboard/_left_nav.html.slim
+++ b/app/views/pages/dashboard/_left_nav.html.slim
@@ -3,7 +3,7 @@ ul.nav.nav-pills.nav-stacked
     li class=('active' if params[:controller] == 'host/supporters' )
       a href=host_supporters_path
         i.fa.fa-smile-o.fa-lg.fa-fw
-        | GET SUPPORTERS!
+        | GIVE $10 TO FRIENDS
     li class=('active' if params[:controller] == 'host/messages'or params[:controller] == 'host/host')
       a href=host_messages_path
         i.fa.fa-inbox.fa-lg.fa-fw

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,8 @@ PetHomestay::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
+  config.action_controller.perform_caching = true
+
   # Log error messages when you accidentally call methods on nil.
   config.whiny_nils = true
 


### PR DESCRIPTION
<img width="689" alt="screen shot 2015-09-28 at 4 31 02 pm" src="https://cloud.githubusercontent.com/assets/6995635/10129183/bab9412c-65fe-11e5-9e68-6012479fe10c.png">
<img width="694" alt="screen shot 2015-09-28 at 4 31 10 pm" src="https://cloud.githubusercontent.com/assets/6995635/10129184/bae1cf20-65fe-11e5-8bd8-631fd65decc2.png">

https://www.pivotaltracker.com/n/projects/1108894/stories/96159164

At this time users can pull out their gmail contacts, and then filter them by whichever one they want. Next Im going to replug that to the sending emails function. The tab "Get Supporters" text has been modified as per the ticket. UI changed as well.

hotfix/HR-96159164

Still in development
