### PR TITLE
id various sections related to supporters from the website as they ar…

### DIFF
--- a/app/views/guest/feedbacks/index.html.slim
+++ b/app/views/guest/feedbacks/index.html.slim
@@ -136,18 +136,12 @@ coffee:
           li.hidden-sm.hidden-xs
             a href="#reviews-received-tab" data-toggle="tab"
               span Reviews Received
-          li.hidden-sm.hidden-xs
-            a href="#recommendation-tab" data-toggle="tab"
-              span Supporters
           li.active.hidden-md.hidden-lg
             a href="#reviews-given-tab" data-toggle="tab"
               i.fa.fa-share
           li.hidden-md.hidden-lg
             a href="#reviews-received-tab" data-toggle="tab"
               i.fa.fa-reply
-          li.hidden-md.hidden-lg
-            a href="#recommendation-tab" data-toggle="tab"
-              i.fa.fa-heart
     .panel-body.phs-panel-body
       .tab-content
         .tab-pane.fade.in.active id="reviews-given-tab"
@@ -269,36 +263,6 @@ coffee:
                         .text-thin style="margin: 5px 0 15px 15px;"
                           = "#{rec_feedback.private_review}"
 
-
-        .tab-pane.fade.in id="recommendation-tab"
-          .phs-subtitle
-            ' Support that you have received from friends and family will appear here. To get more support, tell friends and family to go to the following URL 
-            p = "www.pethomestay.com.au/support/#{current_user.hex}"
-            ' Or use Social media 
-            br
-            br
-            = render 'support_sharing' 
-            '  and get people you know to leave you support!
-          - if @recommendations.any?
-            - @recommendations.each do |recommendation|
-              .parent style="border-bottom: 1px solid #ddd;"
-                .panel-heading.feedback-head style="margin-bottom: 20px;"
-                  .panel-title.phs-title
-                    .pull-left
-                      = "#{recommendation.email}"
-                      br
-                      | Reviewed:
-                      = " (#{time_ago_in_words(recommendation.created_at)}) ago"
-                    .pull-right
-                      .feedback-icon
-                        i.fa.fa-chevron-down  
-                .panel-body.feedback-body style="margin-top: 20px;"
-                  .row
-                    .col-md-12
-                      span "
-                      strong
-                        = recommendation.review
-                      span "
 javascript:
   $( ".feedback-body" ).hide();
   $( ".feedback-head" ).click(function(event) {

--- a/app/views/host/supporters/index.html.slim
+++ b/app/views/host/supporters/index.html.slim
@@ -153,7 +153,7 @@ coffee:
       .text-center.mar-top
         = render 'support_sharing' 
         
-    .phs-panel-body                    
+    .phs-panel-body.hidden                    
       - if @recommendations.any?
         - @recommendations.each do |recommendation|
           - user = User.find(recommendation.user_id)

--- a/app/views/pages/dashboard/_left_nav.html.slim
+++ b/app/views/pages/dashboard/_left_nav.html.slim
@@ -1,9 +1,10 @@
 ul.nav.nav-pills.nav-stacked
   - if params[:controller].include?('host') or request.url.include?("/host")
-    li class=('active' if params[:controller] == 'host/supporters' )
-      a href=host_supporters_path
-        i.fa.fa-smile-o.fa-lg.fa-fw
-        | GET SUPPORTERS!
+    - if current_user.admin? 
+      li.hidden class=('active' if params[:controller] == 'host/supporters' )
+        a href=host_supporters_path
+          i.fa.fa-smile-o.fa-lg.fa-fw
+          | GET SUPPORTERS!
     li class=('active' if params[:controller] == 'host/messages'or params[:controller] == 'host/host')
       a href=host_messages_path
         i.fa.fa-inbox.fa-lg.fa-fw


### PR DESCRIPTION
Hid supporters section because incomplete and need to be fleshed out.

https://www.pivotaltracker.com/n/projects/1108894/stories/96159164

With the previous pull-request I accidentally set it to merge into master which was my mistake. This pull request corrects that by requesting a merge into develop as this was part of a feature ticket. 
Hide the supporters section tab in Host/Supporters as it is not yet complete.
Remove the supporters tab in guest/feedback as guest should not have access to supporters.
Hide the supporters tab in host/feedback as it is not yet complete.

HR-96159164
Complete
